### PR TITLE
Use getWorkSpace instead of getModuleRoot to set the working directory

### DIFF
--- a/src/main/java/hudson/plugins/xshell/XShellBuilder.java
+++ b/src/main/java/hudson/plugins/xshell/XShellBuilder.java
@@ -97,11 +97,11 @@ public final class XShellBuilder extends Builder {
 
     LOG.log(Level.FINEST, "Environment variables: " + env.entrySet().toString());
     LOG.log(Level.FINE, "Command line: " + args.toStringWithQuote());
-    LOG.log(Level.FINE, "Working directory: " + build.getModuleRoot());
+    LOG.log(Level.FINE, "Working directory: " + build.getWorkspace());
 
     try {
       final int result = launcher.decorateFor(build.getBuiltOn()).launch()
-              .cmds(args).envs(env).stdout(listener).pwd(build.getModuleRoot()).join();
+              .cmds(args).envs(env).stdout(listener).pwd(build.getWorkspace()).join();
       return result == 0;
     } catch (final IOException e) {
       Util.displayIOException(e, listener);


### PR DESCRIPTION
Some SCMs (e.g. SVN) support checking out multiple modules into the same workspace. In that case the getModuleRoot is not deterministic anymore. Even if only one module is checked out, the Module Root is not necessarily the same as the Work Space directory. So explicitly use getWorkSpace to conform to the documented behavior: "the current working directory of the command execution is always the job's workspace root."

I am not a java developer and don't have the tools to compile this change. I looked up the alternative for  getModuleRoot in the [documentation](http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html#getWorkspace(\)).
This is also my first commit on github, so I hope I followed the correct workflow for using git.
