### PR TITLE
Don't replace slashes in git URLs. Fixes JENKINS-13243

### DIFF
--- a/src/main/java/hudson/plugins/xshell/XShellBuilder.java
+++ b/src/main/java/hudson/plugins/xshell/XShellBuilder.java
@@ -116,7 +116,7 @@ public final class XShellBuilder extends Builder {
     String replacement = Matcher.quoteReplacement(newSeparator);
 
     Pattern words = Pattern.compile("\\S+");
-    Pattern urls = Pattern.compile("(https*|ftp):");
+    Pattern urls = Pattern.compile("(https*|ftp|git):");
     StringBuffer sb = new StringBuffer();
     Matcher m = words.matcher(cmdLine);
     while (m.find()) {


### PR DESCRIPTION
otherwise git://github.com/user/repo.git becomes git:\github.com\user\repo.git 

see https://issues.jenkins-ci.org/browse/JENKINS-13243?focusedCommentId=178712&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-178712
