### PR TITLE
Fail job on regex found in STDOUT or running over allotted time

### DIFF
--- a/src/main/java/hudson/plugins/xshell/XShellBuilder.java
+++ b/src/main/java/hudson/plugins/xshell/XShellBuilder.java
@@ -1,28 +1,21 @@
 package hudson.plugins.xshell;
 
-import java.io.*;
-import java.util.Map;
-
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.Launcher;
-import hudson.Util;
+import hudson.*;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
+import hudson.model.StreamBuildListener;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
-import hudson.Proc;
-import hudson.model.StreamBuildListener;
+import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * XShell Builder Plugin.
@@ -132,7 +125,7 @@ public final class XShellBuilder extends Builder {
     try{
         timeAllowed = Long.parseLong(this.timeAllocated);
     }catch(Exception e){
-        timeAllowed = new Long(0);
+        timeAllowed = (long) 0;
     }
 
     try {
@@ -162,7 +155,7 @@ public final class XShellBuilder extends Builder {
             child.kill();
             listener.getLogger().println("Timed out <" + this.timeAllocated +">. Terminated");
         }else{
-          Thread.currentThread().sleep(2);
+          Thread.sleep(2);
         }
       }
 

--- a/src/main/resources/hudson/plugins/xshell/XShellBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/xshell/XShellBuilder/config.jelly
@@ -6,5 +6,10 @@
     <f:entry title="${%Executable is in workspace dir}" help="${rootURL}/../plugin/xshell/help-workingdir.html">
         <f:checkbox name="xshellBuilder.executeFromWorkingDir" checked="${instance.executeFromWorkingDir}" />
     </f:entry>
-
+    <f:entry title="${%Regex to kill job}" help="${rootURL}/../plugin/xshell/help-regex.html">
+        <f:textbox name="xshellBuilder.regexToKill" value="${instance.regexToKill}" />
+    </f:entry>
+    <f:entry title="${%Time allocated}" help="${rootURL}/../plugin/xshell/help-time.html">
+        <f:number name="xshellBuilder.timeAllocated" value="${instance.timeAllocated}" />
+    </f:entry>
 </j:jelly>

--- a/src/main/webapp/help-regex.html
+++ b/src/main/webapp/help-regex.html
@@ -1,0 +1,4 @@
+<div>
+  <p>If the output from the step matches this regex then the step is killed
+  </p>
+</div>

--- a/src/main/webapp/help-time.html
+++ b/src/main/webapp/help-time.html
@@ -1,0 +1,4 @@
+<div>
+  <p>Only allow the step to run for this amount of time. If it goes over then the step is killed
+  </p>
+</div>


### PR DESCRIPTION
Hi

I saw a couple of requests on StackOverflow for the ability to halt a job if something is found in the log. I thought it was a good idea so forked xshell-plugin and developed it. So here it is. I tested it on debian in a master node and a slave configuration.

I looked for a way to poll ByteArrayOutputStream rather than sleep but couldn't see anything obvious

If you like it please add it in

Regards
Jeremy
