### PR TITLE
Require Jenkins 2.332.4 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,17 +42,25 @@
     <url>https://github.com/jenkinsci/xshell-plugin</url>
   </scm>
 
+  <properties>
+    <jenkins.version>2.332.4</jenkins.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1706.vc166d5f429f8</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Require Jenkins 2.332.4 or newer

Older versions have security vulnerabilities reported.  Chose an older version to allow as many to upgrade as feasible, without going too far back in time.

Removes the implicit dependency on windows-slaves plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
