### PR TITLE
Enable Java cache in security scan

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,8 +1,11 @@
+# Jenkins Security Scan
+# For more information, see: https://www.jenkins.io/doc/developer/security/scan/
+
 name: Jenkins Security Scan
 on:
   push:
     branches:
-      - "master"
+      - master
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
@@ -16,5 +19,5 @@ jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
-      java-cache: '' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
       java-version: 11 # What version of Java to set up for the build.


### PR DESCRIPTION
## Enable Java cache in security scan

Reduce load on repo.jenkins-ci.org.  Also adds consistent comments and content formatting with other plugins that I maintain.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
