### PR TITLE
Enable cleanThat refactor & palantir formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/xshell-plugin</gitHubRepo>
     <jenkins.version>2.361.4</jenkins.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,9 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.36.0</version>
           <configuration>
+            <cleanThat>
+              <version>2.14</version>
+            </cleanThat>
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->

--- a/src/main/java/hudson/plugins/xshell/XShellBuilder.java
+++ b/src/main/java/hudson/plugins/xshell/XShellBuilder.java
@@ -29,7 +29,8 @@ public final class XShellBuilder extends Builder {
     public static final String UNIX_SEP = "/";
     public static final String WINDOWS_SEP = "\\";
 
-    @Extension public static final XShellDescriptor DESCRIPTOR = new XShellDescriptor();
+    @Extension
+    public static final XShellDescriptor DESCRIPTOR = new XShellDescriptor();
 
     /** Command line. */
     private final String commandLine;
@@ -86,8 +87,7 @@ public final class XShellBuilder extends Builder {
     }
 
     @Override
-    public boolean perform(
-            final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
+    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
             throws InterruptedException, IOException {
 
         LOG.log(Level.FINE, "Unmodified command line: " + commandLine);
@@ -96,8 +96,7 @@ public final class XShellBuilder extends Builder {
 
         final EnvVars env = build.getEnvironment(listener);
 
-        String cmdLine =
-                convertSeparator(commandLine, (launcher.isUnix() ? UNIX_SEP : WINDOWS_SEP));
+        String cmdLine = convertSeparator(commandLine, (launcher.isUnix() ? UNIX_SEP : WINDOWS_SEP));
         LOG.log(Level.FINE, "File separators sanitized: " + cmdLine);
 
         cmdLine = env.expand(cmdLine);
@@ -113,8 +112,7 @@ public final class XShellBuilder extends Builder {
 
         ArgumentListBuilder args = new ArgumentListBuilder();
         if (cmdLine != null) {
-            args.addTokenized(
-                    (launcher.isUnix() && executeFromWorkingDir) ? "./" + cmdLine : cmdLine);
+            args.addTokenized((launcher.isUnix() && executeFromWorkingDir) ? "./" + cmdLine : cmdLine);
             LOG.log(Level.FINE, "Execute from working directory: " + args.toStringWithQuote());
         }
 
@@ -131,10 +129,7 @@ public final class XShellBuilder extends Builder {
         if (new File(nonNullWorkingDir).isAbsolute()) {
             absWorkingDir = nonNullWorkingDir;
         } else {
-            absWorkingDir =
-                    build.getWorkspace()
-                            + (launcher.isUnix() ? UNIX_SEP : WINDOWS_SEP)
-                            + nonNullWorkingDir;
+            absWorkingDir = build.getWorkspace() + (launcher.isUnix() ? UNIX_SEP : WINDOWS_SEP) + nonNullWorkingDir;
         }
 
         LOG.log(Level.FINEST, "Environment variables: " + env.entrySet().toString());
@@ -154,14 +149,13 @@ public final class XShellBuilder extends Builder {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             StreamBuildListener sbl = new StreamBuildListener(baos);
 
-            final Proc child =
-                    launcher.decorateFor(build.getBuiltOn())
-                            .launch()
-                            .cmds(args)
-                            .envs(env)
-                            .stdout(sbl)
-                            .pwd(absWorkingDir)
-                            .start();
+            final Proc child = launcher.decorateFor(build.getBuiltOn())
+                    .launch()
+                    .cmds(args)
+                    .envs(env)
+                    .stdout(sbl)
+                    .pwd(absWorkingDir)
+                    .start();
 
             Long startTime = System.currentTimeMillis();
 
@@ -180,15 +174,11 @@ public final class XShellBuilder extends Builder {
                             && (r.matcher(s).find())) {
                         LOG.log(Level.FINEST, "Matched failure in log");
                         child.kill();
-                        listener.getLogger()
-                                .println(
-                                        "Matched <" + this.regexToKill + "> in output. Terminated");
-                    } else if ((timeAllowed > 0)
-                            && ((System.currentTimeMillis() - startTime) / 1000) > timeAllowed) {
+                        listener.getLogger().println("Matched <" + this.regexToKill + "> in output. Terminated");
+                    } else if ((timeAllowed > 0) && ((System.currentTimeMillis() - startTime) / 1000) > timeAllowed) {
                         LOG.log(Level.FINEST, "Timed out");
                         child.kill();
-                        listener.getLogger()
-                                .println("Timed out <" + this.timeAllocated + ">. Terminated");
+                        listener.getLogger().println("Timed out <" + this.timeAllocated + ">. Terminated");
                     } else {
                         Thread.sleep(2);
                     }
@@ -226,8 +216,7 @@ public final class XShellBuilder extends Builder {
                 // Not sure if File.separator is right if executing on slave with OS different from
                 // master's one
                 // String cmdLine = commandLine.replaceAll("[/\\\\]", File.separator);
-                m.appendReplacement(
-                        sb, Matcher.quoteReplacement(item.replaceAll(match, replacement)));
+                m.appendReplacement(sb, Matcher.quoteReplacement(item.replaceAll(match, replacement)));
             }
         }
         m.appendTail(sb);

--- a/src/main/java/hudson/plugins/xshell/XShellDescriptor.java
+++ b/src/main/java/hudson/plugins/xshell/XShellDescriptor.java
@@ -40,8 +40,7 @@ public final class XShellDescriptor extends BuildStepDescriptor<Builder> {
     }
 
     @Override
-    public XShellBuilder newInstance(final StaplerRequest req, final JSONObject formData)
-            throws FormException {
+    public XShellBuilder newInstance(final StaplerRequest req, final JSONObject formData) throws FormException {
         return req.bindJSON(XShellBuilder.class, formData);
     }
 }

--- a/src/test/java/hudson/plugins/xshell/UpgradeTest.java
+++ b/src/test/java/hudson/plugins/xshell/UpgradeTest.java
@@ -24,7 +24,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 @RunWith(JUnit4.class)
 public class UpgradeTest extends HudsonTestCase {
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     /**
      * XShell upgrade from 0.8 to 0.9 reported a null pointer exception when the job was first
@@ -36,8 +37,7 @@ public class UpgradeTest extends HudsonTestCase {
      */
     @Test
     @Bug(20660)
-    public void testXShellBuilderNullAsRegExToKill()
-            throws IOException, InterruptedException, ExecutionException {
+    public void testXShellBuilderNullAsRegExToKill() throws IOException, InterruptedException, ExecutionException {
 
         FreeStyleProject project = j.createFreeStyleProject();
 
@@ -48,13 +48,7 @@ public class UpgradeTest extends HudsonTestCase {
         final String timeAllocated = null;
 
         project.getBuildersList()
-                .add(
-                        new XShellBuilder(
-                                "echo " + arguments,
-                                "",
-                                execFromWorkingDir,
-                                regexToKill,
-                                timeAllocated));
+                .add(new XShellBuilder("echo " + arguments, "", execFromWorkingDir, regexToKill, timeAllocated));
 
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         String s = FileUtils.readFileToString(build.getLogFile());

--- a/src/test/java/hudson/plugins/xshell/XShellBuilderTest.java
+++ b/src/test/java/hudson/plugins/xshell/XShellBuilderTest.java
@@ -28,9 +28,11 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public class XShellBuilderTest {
 
-    @ClassRule public static JenkinsRule rule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule rule = new JenkinsRule();
 
-    @Rule public TestName testName = new TestName();
+    @Rule
+    public TestName testName = new TestName();
 
     public XShellBuilderTest() {}
 
@@ -50,9 +52,7 @@ public class XShellBuilderTest {
         executeFromWorkingDir = false;
         regexToKill = random.nextBoolean() ? null : "xyzzy.*grue";
         timeAllocated = random.nextBoolean() ? null : "37";
-        builder =
-                new XShellBuilder(
-                        commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
+        builder = new XShellBuilder(commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
     }
 
     @Test
@@ -68,9 +68,7 @@ public class XShellBuilderTest {
     @Test
     public void testGetWorkingDirNull() {
         workingDir = null;
-        builder =
-                new XShellBuilder(
-                        commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
+        builder = new XShellBuilder(commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
         assertThat(builder.getWorkingDir(), is(workingDir));
     }
 
@@ -108,9 +106,7 @@ public class XShellBuilderTest {
         BuildListener listener = new StreamBuildListener(outputStream, Charset.forName("UTF-8"));
         AbstractBuild build = project.scheduleBuild2(0).get();
         workingDir = null;
-        builder =
-                new XShellBuilder(
-                        commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
+        builder = new XShellBuilder(commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
         assertTrue("Failed in perform", builder.perform(build, launcher, listener));
     }
 
@@ -122,9 +118,7 @@ public class XShellBuilderTest {
         BuildListener listener = new StreamBuildListener(outputStream, Charset.forName("UTF-8"));
         AbstractBuild build = project.scheduleBuild2(0).get();
         workingDir = System.getProperty("java.io.tmpdir");
-        builder =
-                new XShellBuilder(
-                        commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
+        builder = new XShellBuilder(commandLine, workingDir, executeFromWorkingDir, regexToKill, timeAllocated);
         assertTrue("Failed in perform", builder.perform(build, launcher, listener));
     }
 
@@ -143,9 +137,7 @@ public class XShellBuilderTest {
     @Test
     public void testConvertEnvVarsToUnix() {
         commandLine = "set PATH=C:\\;";
-        assertThat(
-                XShellBuilder.convertEnvVarsToUnix(commandLine + WINDOWS_ENV_VAR),
-                is(commandLine + UNIX_ENV_VAR));
+        assertThat(XShellBuilder.convertEnvVarsToUnix(commandLine + WINDOWS_ENV_VAR), is(commandLine + UNIX_ENV_VAR));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/xshell/XShellTest.java
+++ b/src/test/java/hudson/plugins/xshell/XShellTest.java
@@ -9,7 +9,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  * @author marco.ambu
  */
 public class XShellTest {
-    @Rule public JenkinsRule jenkinsRule = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Test
     public void testConvertSeparatorUnixToWin() throws Exception {


### PR DESCRIPTION
## Enable palantir formatter & cleanThat refactor

- Use palantir Java formatter
- Maximum spotbugs effort, low threshold
- Refactor automatically with cleanThat for spotless

Reduce maintenance with consistent automated formatting aligned with other plugins I maintain.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
