### PR TITLE
Use parent pom 4.59 with formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.58</version>
+    <version>4.59</version>
     <relativePath />
   </parent>
 
@@ -89,53 +89,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.36.0</version>
-          <configuration>
-            <!-- define a language-specific format -->
-            <java>
-              <!-- no need to specify files, inferred automatically -->
-              <endWithNewline />
-              <palantirJavaFormat />
-              <removeUnusedImports />
-            </java>
-            <pom>
-              <indent>
-                <spaces>true</spaces>
-              </indent>
-              <includes>
-                <include>pom.xml</include>
-                <include>src/spotbugs/excludesFilter.xml</include>
-              </includes>
-              <sortPom>
-                <expandEmptyElements>false</expandEmptyElements>
-                <sortDependencies>groupId,artifactId</sortDependencies>
-                <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
-                <sortExecutions>true</sortExecutions>
-                <sortModules>true</sortModules>
-                <sortPlugins>groupId,artifactId</sortPlugins>
-                <sortProperties>true</sortProperties>
-                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-              </sortPom>
-            </pom>
-          </configuration>
-          <executions>
-            <execution>
-              <!-- Runs in verify phase by default -->
-              <goals>
-                <!-- Can be disabled using -Dspotless.check.skip -->
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>


### PR DESCRIPTION
## Use parent pom 4.59 and enable automatic formatting

Removes all the formatting configuration and unifies on a single consistent formatting standard.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
