### PR TITLE
Use hamcrest assertThat, not deprecated JUnit assertThat

### DIFF
--- a/src/test/java/hudson/plugins/xshell/UpgradeTest.java
+++ b/src/test/java/hudson/plugins/xshell/UpgradeTest.java
@@ -2,7 +2,7 @@ package hudson.plugins.xshell;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;


### PR DESCRIPTION
## Use hamcrest assertThat, not deprecated JUnit assertThat

[https://docs.openrewrite.org/recipes/java/testing/junit5/usehamcrestassertthat](OpenRewrite) made this change automatically when I ran it with the command:

```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:RELEASE \
  -Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.UseHamcrestAssertThat
```

### Testing done

Confirmed tests pass on Linux with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
